### PR TITLE
Update package name to square namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orbit-icons",
+  "name": "@square/orbit-icons",
   "version": "1.0.0",
   "description": "Orbit Icons",
   "author": "Hiroki Osame <hiroki.osame@gmail.com>",


### PR DESCRIPTION
Adding the Square namespace to the package name to stay consistent with the `@square/orbit` dependency name. 